### PR TITLE
update package json: add blog command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "ci:env": "touch .env && echo PRISMIC_ENDPOINT=$PRISMIC_ENDPOINT >> .env",
     "ci": "npm run ci:env && npm run build",
-    "build": "stencil build --prerender",
-    "start": "stencil build --dev --watch --watchAll --serve",
+    "build": "npm run blog && stencil build --prerender",
+    "start": "npm run blog && stencil build --dev --watch --watchAll --serve",
     "generate": "stencil generate",
-    "serve": "stencil build --dev --watch",
-    "dev": "stencil build --dev --watch --serve",
+    "serve": "npm run blog && stencil build --dev --watch",
+    "dev": "npm run blog && stencil build --dev --watch --serve",
     "blog": "blog"
   },
   "devDependencies": {


### PR DESCRIPTION
Add blog command to various scripts. Otherwise, it's easy to miss that you have to run this if you say, update a blog markdown file and wonder why changes haven't taken effect.  :)

Also, Vercel deployments run "build", so this will ensure blog is rebuilt when merged into main branch.